### PR TITLE
chore: update LICENSE copyright holder for GitHub recognition

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 SurrealDB MCP Server Contributors
+Copyright (c) 2024 Luis Novo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Update the LICENSE file copyright to use the specific copyright holder name instead of generic 'Contributors'. This helps GitHub's license detection system properly recognize and display the MIT license.